### PR TITLE
fix: the manifest is missing a swift tools version specification 이슈 해결

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
- consider prepending to the manifest '// swift-tools-version: 5.6
- 5.6으로 올리라는 의미로 보여 그에 따라 수정함